### PR TITLE
Fix broken supported format detection and reading MP3 files

### DIFF
--- a/alooper/xui.h
+++ b/alooper/xui.h
@@ -28,8 +28,6 @@
 
 class SupportedFormats {
 public:
-    std::set<std::string> supportedExtensions;
-
     SupportedFormats() {
         supportedExtensions = getSupportedFileExtensions();
     }
@@ -48,11 +46,10 @@ public:
     }
 
 private:
+    std::set<std::string> supportedExtensions;
+
     std::set<std::string> getSupportedFileExtensions() {
         std::set<std::string> extensions;
-        SF_INFO sfInfo;
-        int format;
-
 
         // Get the number of supported major formats
         int majorFormatCount;
@@ -62,35 +59,31 @@ private:
         int subFormatCount;
         sf_command(SF_NULL, SFC_GET_FORMAT_SUBTYPE_COUNT, &subFormatCount, sizeof(int));
 
-        sfInfo.channels = 1;
-
         // Get information about each major format
-        for (int i = 0; i < majorFormatCount; ++i) {
+        for (int i = 0; i < majorFormatCount; i++) {
             SF_FORMAT_INFO formatInfo;
             formatInfo.format = i;
             sf_command(SF_NULL, SFC_GET_FORMAT_MAJOR, &formatInfo, sizeof(formatInfo));
 
-            format = formatInfo.format;
             if (formatInfo.extension != SF_NULL) {
                 extensions.insert(formatInfo.extension);
             }
-
-            // Get information about each sub format
-            for (int j = 0; j < subFormatCount; ++j) {
-                SF_FORMAT_INFO formatInfo;
-                formatInfo.format = j;
-                sf_command(SF_NULL, SFC_GET_FORMAT_SUBTYPE, &formatInfo, sizeof(SF_FORMAT_INFO));
-
-                format = (format & SF_FORMAT_TYPEMASK) | formatInfo.format;
-
-                sfInfo.format = format;
-                if (sf_format_check(&sfInfo) && formatInfo.extension != SF_NULL) {
-                    extensions.insert(formatInfo.extension);
-                }
-            }
-
         }
-        extensions.insert("ogg");
+
+        // Get information about each sub format
+        for (int j = 0; j < subFormatCount; j++) {
+            SF_FORMAT_INFO formatInfo;
+            formatInfo.format = j;
+            sf_command(SF_NULL, SFC_GET_FORMAT_SUBTYPE, &formatInfo, sizeof(SF_FORMAT_INFO));
+
+            if (formatInfo.extension != SF_NULL) {
+                extensions.insert(formatInfo.extension);
+            }
+        }
+
+        if (extensions.count("oga") >= 1)
+            extensions.insert("ogg");
+
         return extensions;
     }
 };
@@ -122,7 +115,6 @@ public:
         loadNew = false;
         play = true;
         ready = true;
-        supportedFormats = SupportedFormats();
     };
 
     ~AudioLooperUi() {

--- a/alooper/xui.h
+++ b/alooper/xui.h
@@ -220,13 +220,12 @@ private:
             return ;
         }
         if (info.channels > 2) {
-            std::cerr << "Error: Maximal two channels been supported!" << std::endl;
+            std::cerr << "Error: only two channels maximum are supported!" << std::endl;
             return ;
         }
         samples = new float[info.frames * info.channels];
-        sf_readf_float(sndfile, &samples[0], info.frames );
+        samplesize = (uint32_t) sf_readf_float(sndfile, &samples[0], info.frames);
         channels = info.channels;
-        samplesize = info.frames;
         samplerate = info.samplerate;
         position = 0;
         sf_close(sndfile);


### PR DESCRIPTION
* fix: remove fault validity check for subformats
    
    Checking for validity of a subformat without a sample rate, which is not known at this point, gives undefined results, leading to the list of supported file extension randomly being incomplete.

    This fix, therefor removes this check and just collects the set of file extensions for all supported formats and subformats.
 
* fix: determine `samplesize` from # of frames actually read
    
    The `SF_INFO` `frames` field can be inaccurate, e.g. when reading MP3 files. See https://github.com/libsndfile/libsndfile/issues/1001
  